### PR TITLE
Add support for multiple MQTT servers in a cluster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,5 +68,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+py-modules = []
+
 [tool.setuptools.dynamic]
 version = {attr = "_version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "aiomqtt ~= 2.3.0",
     "asyncpg ~= 0.30.0",
     "python-decouple ~= 3.8",
+    "pydantic ~= 2.10.5",
 ]
 dynamic = ["version"]
 

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -1,0 +1,44 @@
+"""
+Tests for the input environment variable parser.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from typedefs import MQTTParams
+
+
+@pytest.mark.parametrize(
+    ["hosts", "result"],
+    [
+        ["example.com", [("example.com", 1883)]],
+        ["example.com:1234", [("example.com", 1234)]],
+        ["example1.com,example2.com", [("example1.com", 1883), ("example2.com", 1883)]],
+        ["example1.com, example2.com", [("example1.com", 1883), ("example2.com", 1883)]],
+        ["example1.com:1234,example2.com", [("example1.com", 1234), ("example2.com", 1883)]],
+        ["example1.com:1234,example2.com:0", [("example1.com", 1234), ("example2.com", 1883)]],
+    ],
+)
+def test_hostnames_pass(hosts, result):
+    """
+    Test parsing hostname(s) from env variables.
+    """
+    env_params = MQTTParams(hosts=hosts, client_id="foo", username="bar", password="12345")
+
+    assert env_params.hosts == result
+
+
+@pytest.mark.parametrize(
+    ["hosts", "expectation"],
+    [
+        ["example.com:123456", pytest.raises(ValidationError)],
+        ["e^xample.com", pytest.raises(ValidationError)],
+        ["example.com:-1", pytest.raises(ValidationError)],
+    ],
+)
+def test_hostnames_fail(hosts, expectation):
+    """
+    Test parsing hostname(s) from env variables. Test invalid hostnames.
+    """
+    with expectation:
+        MQTTParams(hosts=hosts, client_id="foo", username="bar", password="12345")

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -5,7 +5,7 @@ Tests for the input environment variable parser.
 import pytest
 from pydantic import ValidationError
 
-from typedefs import MQTTParams
+from typedefs import DatabaseParams, MQTTParams
 
 
 @pytest.mark.parametrize(
@@ -42,3 +42,36 @@ def test_mqtt_hostnames_fail(hosts, expectation):
     """
     with expectation:
         MQTTParams(hosts=hosts, identifier="foo", username="bar", password="12345")
+
+
+@pytest.mark.parametrize(
+    ["host", "result"],
+    [
+        ["example.com", ("example.com", 5432)],
+        ["example.com:1234", ("example.com", 1234)],
+    ],
+)
+def test_database_hostnames_pass(host, result):
+    """
+    Test parsing hostname(s) from env variables.
+    """
+    env_params = DatabaseParams(host=host, username="bar", password="12345", database="sensors")
+
+    assert env_params.host == result
+
+
+@pytest.mark.parametrize(
+    ["host", "expectation"],
+    [
+        ["example1.com,example2.com", pytest.raises(ValidationError)],
+        ["example.com:123456", pytest.raises(ValidationError)],
+        ["e^xample.com", pytest.raises(ValidationError)],
+        ["example.com:-1", pytest.raises(ValidationError)],
+    ],
+)
+def test_database_hostnames_fail(host, expectation):
+    """
+    Test parsing hostname(s) from env variables. Test invalid hostnames.
+    """
+    with expectation:
+        DatabaseParams(host=host, username="bar", password="12345", database="sensors")

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -19,11 +19,11 @@ from typedefs import MQTTParams
         ["example1.com:1234,example2.com:0", [("example1.com", 1234), ("example2.com", 1883)]],
     ],
 )
-def test_hostnames_pass(hosts, result):
+def test_mqtt_hostnames_pass(hosts, result):
     """
     Test parsing hostname(s) from env variables.
     """
-    env_params = MQTTParams(hosts=hosts, client_id="foo", username="bar", password="12345")
+    env_params = MQTTParams(hosts=hosts, identifier="foo", username="bar", password="12345")
 
     assert env_params.hosts == result
 
@@ -36,9 +36,9 @@ def test_hostnames_pass(hosts, result):
         ["example.com:-1", pytest.raises(ValidationError)],
     ],
 )
-def test_hostnames_fail(hosts, expectation):
+def test_mqtt_hostnames_fail(hosts, expectation):
     """
     Test parsing hostname(s) from env variables. Test invalid hostnames.
     """
     with expectation:
-        MQTTParams(hosts=hosts, client_id="foo", username="bar", password="12345")
+        MQTTParams(hosts=hosts, identifier="foo", username="bar", password="12345")

--- a/typedefs.py
+++ b/typedefs.py
@@ -67,3 +67,48 @@ class MQTTParams(BaseModel):
                 )
             )
         return result
+
+
+class DatabaseParams(BaseModel):
+    """
+    Parameters used to connect to the database.
+
+    Parameters
+    ----------
+    host: Tuple of str and int
+        A tuple host:port. If port number 0 is provided the default value of 5432 is used.
+    username: str or None
+        The username used for authentication. Set to None if no username is required
+    password: str or None
+        The password used for authentication. Set to None if no username is required
+    database: str
+        The database name
+    """
+
+    host: tuple[str, int]
+    username: str | None
+    password: str | None
+    database: str
+
+    @field_validator("host", mode="before")
+    @classmethod
+    def ensure_hostname(cls, value: str) -> tuple[str, int]:
+        """
+        Parse
+        Parameters
+        ----------
+        value: str
+            A single hostname:port string.
+
+        Returns
+        -------
+        list of tuple of str and int
+            A list of (hostname, port) tuples.
+        """
+        match = re.search(HOSTNAME_REGEX, value)
+        if match is None:
+            raise ValueError(f"'{value}' is not a valid hostname.")
+        return (
+            match.group(1),
+            int(match.group(2)) if match.group(2) and not match.group(2) == "0" else 5432,
+        )

--- a/typedefs.py
+++ b/typedefs.py
@@ -24,8 +24,8 @@ class MQTTParams(BaseModel):
     ----------
     hosts: List of Tuple of str and int
         A list of host:port tuples. The list contains the servers of a cluster. If no port is provided it defaults to
-        1883. If port number 0 is provided the default value of 1883 is used as well.
-    client_id: str or None
+        1883. If port number 0 is provided the default value of 1883 is used.
+    identifier: str or None
         An MQTT client id used to uniquely identify a client to persist messages.
     username: str or None
         The username used for authentication. Set to None if no username is required
@@ -34,7 +34,7 @@ class MQTTParams(BaseModel):
     """
 
     hosts: list[tuple[str, int]]
-    client_id: str | None
+    identifier: str | None
     username: str | None
     password: str | None
 

--- a/typedefs.py
+++ b/typedefs.py
@@ -1,0 +1,69 @@
+"""
+Pydantic type definitions for the input validator
+"""
+
+import re
+
+from pydantic import BaseModel, field_validator
+
+# A regular expression to match a hostname with an optional port.
+# It adheres to RFC 1035 (https://www.rfc-editor.org/rfc/rfc1035) and matches ports
+# between 0-65535.
+HOSTNAME_REGEX = (
+    r"^((?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:["
+    r"0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?)(?:\:([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{"
+    r"2}|655[0-2][0-9]|6553[0-5]))?$"
+)
+
+
+class MQTTParams(BaseModel):
+    """
+    Parameters used to connect to the MQTT broker.
+
+    Parameters
+    ----------
+    hosts: List of Tuple of str and int
+        A list of host:port tuples. The list contains the servers of a cluster. If no port is provided it defaults to
+        1883. If port number 0 is provided the default value of 1883 is used as well.
+    client_id: str or None
+        An MQTT client id used to uniquely identify a client to persist messages.
+    username: str or None
+        The username used for authentication. Set to None if no username is required
+    password: str or None
+        The password used for authentication. Set to None if no username is required
+    """
+
+    hosts: list[tuple[str, int]]
+    client_id: str | None
+    username: str | None
+    password: str | None
+
+    @field_validator("hosts", mode="before")
+    @classmethod
+    def ensure_list_of_hosts(cls, value: str) -> list[tuple[str, int]]:
+        """
+        Parse
+        Parameters
+        ----------
+        value: str
+            Either a single hostname:port string or a comma separated list of hostname:port strings.
+
+        Returns
+        -------
+        list of tuple of str and int
+            A list of (hostname, port) tuples.
+        """
+        hosts = value.split(",")
+        result = []
+        for host in hosts:
+            host = host.strip()
+            match = re.search(HOSTNAME_REGEX, host)
+            if match is None:
+                raise ValueError(f"'{value}' is not a valid hostname or list of hostnames.")
+            result.append(
+                (
+                    match.group(1),
+                    int(match.group(2)) if match.group(2) and not match.group(2) == "0" else 1883,
+                )
+            )
+        return result


### PR DESCRIPTION
BREAKING CHANGE: Dropped the env variable `MQTT_PORT`.

The variable was replaced with a new SYNTAX for `MQTT_HOST`. This variable now allows `host:port` strings and also comma separated lists of `host:port`. The new variable has input validation using Pydantic.